### PR TITLE
Add Pandoc conversion to deployment workflow

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -48,6 +48,13 @@ jobs:
         with:
           ref: ${{ steps.pick.outputs.ref }}
 
+      # 3.5) Conversion Markdown -> HTML
+      - name: Convert texte.md to texte.html
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+          pandoc texte.md -t html -o texte.html
+
       # 4) Site statique sans build
       - name: Upload artifact (static site)
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- install Pandoc in the Pages workflow and convert texte.md to texte.html before uploading artifacts

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_6909c648d49883288a38c88e2617605d